### PR TITLE
Temporary solution (I hope)

### DIFF
--- a/proxy-check/run.yml
+++ b/proxy-check/run.yml
@@ -1,0 +1,15 @@
+name: "Restart Proxy US"
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  jobs:
+    restart_proxy_us:
+      name: "Restart proxy US"
+      runs_on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - uses: superfly/flyctl-actions/setup-flyctl@master
+        - run: |
+            fly apps restart -a platform-us-proxy
+          env:
+            FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
This restarts proxy daily to help us avoid emfile outages. We're doing this because Apps v2 does not restart machines on health check failures.