### PR TITLE
OSS-151: fix hub release URLs

### DIFF
--- a/argodeploy/install.sh
+++ b/argodeploy/install.sh
@@ -16,7 +16,7 @@ if [[ $1 == "false" ]]; then
   echo "Done!"
 fi
 
-VER=$(curl -s https://api.github.com/repos/github/hub/releases/latest | grep tag_name | cut -d '"' -f 4)
+VER=$(curl -s https://api.github.com/repositories/401025/releases/latest | grep tag_name | cut -d '"' -f 4)
 echo -n "Installing Hub@${VER}..."
 wget -q https://github.com/github/hub/releases/download/${VER}/hub-linux-amd64-${VER:1}.tgz
 tar -xvf hub-linux-amd64-${VER:1}.tgz &>/dev/null

--- a/check-update/setup.sh
+++ b/check-update/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if ! hash hub 2>/dev/null; then
-  VER=$(curl -s https://api.github.com/repos/github/hub/releases/latest | grep tag_name | cut -d '"' -f 4)
+  VER=$(curl -s https://api.github.com/repositories/401025/releases/latest | grep tag_name | cut -d '"' -f 4)
   echo -n "Installing Hub@${VER}..."
   wget -q https://github.com/github/hub/releases/download/${VER}/hub-linux-amd64-${VER:1}.tgz
   tar -xvf hub-linux-amd64-${VER:1}.tgz &>/dev/null

--- a/eks-access/install.sh
+++ b/eks-access/install.sh
@@ -11,7 +11,7 @@ sudo apt-get update -qq
 sudo apt install -y -qq git timelimit jq &>/dev/null
 echo "Done!"
 
-VER=$(curl -s https://api.github.com/repos/github/hub/releases/latest | grep tag_name | cut -d '"' -f 4)
+VER=$(curl -s https://api.github.com/repositories/401025/releases/latest | grep tag_name | cut -d '"' -f 4)
 echo -n "Installing Hub@${VER}..."
 wget -q https://github.com/github/hub/releases/download/${VER}/hub-linux-amd64-${VER:1}.tgz
 tar -xvf hub-linux-amd64-${VER:1}.tgz &>/dev/null


### PR DESCRIPTION
In pursuit of re-enabling the Github Actions pipelines for the Kubernetes cluster repos, this PR fixes the version list URL for the `hub` binary.  I've fixed the URL in additional locations unrelated to the Kubernetes pipelines.  URL taken from https://github.com/kualibuild/github-actions/pull/19